### PR TITLE
Show correct heirloom/scaled items in comments & get Russian realm names

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,4 +3,7 @@ externals:
   libs/AceAddon-3.0: svn://svn.wowace.com/wow/ace3/mainline/trunk/AceAddon-3.0
   libs/AceConsole-3.0: svn://svn.wowace.com/wow/ace3/mainline/trunk/AceConsole-3.0
   libs/AceEvent-3.0: svn://svn.wowace.com/wow/ace3/mainline/trunk/AceEvent-3.0
+  libs/LibItemUpgradeInfo-1.0:
+    url: git://git.wowace.com/wow/libitemupgradeinfo-1-0/mainline.git
+    tag: latest
 

--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -7,11 +7,11 @@
 
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
-libs\LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.lua
 #@no-lib-strip@
 libs\AceAddon-3.0\AceAddon-3.0.xml
 libs\AceConsole-3.0\AceConsole-3.0.xml
 libs\AceEvent-3.0\AceEvent-3.0.xml
+libs\LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.xml
 #@end-no-lib-strip@
 
 embeds.xml

--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -2,11 +2,12 @@
 ## Title: Simulationcraft
 ## Notes: Constructs SimC export strings
 ## Author: Theck, navv_
-## Version: 1.8.4
+## Version: 1.8.5
 ## OptionalDependencies: Ace3
 
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
+libs\LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.lua
 #@no-lib-strip@
 libs\AceAddon-3.0\AceAddon-3.0.xml
 libs\AceConsole-3.0\AceConsole-3.0.xml

--- a/core.lua
+++ b/core.lua
@@ -80,6 +80,21 @@ local function GetItemSplit(itemLink)
   return itemSplit
 end
 
+-- char size for utf8 strings
+local function chsize(char)
+  if not char then
+      return 0
+  elseif char > 240 then
+      return 4
+  elseif char > 225 then
+      return 3
+  elseif char > 192 then
+      return 2
+  else
+      return 1
+  end
+end
+
 -- SimC tokenize function
 local function tokenize(str)
   str = str or ""
@@ -90,6 +105,7 @@ local function tokenize(str)
   -- keep stuff we want, dumpster everything else
   local s = ""
   for i=1,str:len() do
+    local b = str:byte(i)
     -- keep digits 0-9
     if str:byte(i) >= 48 and str:byte(i) <= 57 then
       s = s .. str:sub(i,i)
@@ -99,6 +115,11 @@ local function tokenize(str)
       -- keep %, +, ., _
     elseif str:byte(i)==37 or str:byte(i)==43 or str:byte(i)==46 or str:byte(i)==95 then
       s = s .. str:sub(i,i)
+      -- save all multibyte chars
+    elseif chsize(b) > 1 then
+      local offset = chsize(b) - 1
+      s = s .. str:sub(i, i + offset)
+      i = i + offset
     end
   end
   -- strip trailing spaces

--- a/core.lua
+++ b/core.lua
@@ -1,6 +1,7 @@
 local _, Simulationcraft = ...
 
 Simulationcraft = LibStub("AceAddon-3.0"):NewAddon(Simulationcraft, "Simulationcraft", "AceConsole-3.0", "AceEvent-3.0")
+ItemUpgradeInfo = LibStub("LibItemUpgradeInfo-1.0")
 
 local OFFSET_ITEM_ID = 1
 local OFFSET_ENCHANT_ID = 2
@@ -493,11 +494,15 @@ function Simulationcraft:GetBagItemStrings()
           _, _, _, _, _, _, itemLink, _, _, itemId = GetContainerItemInfo(container, slot)
           if itemLink then
             local name, link, quality, iLevel, reqLevel, class, subclass, maxStack, equipSlot, texture, vendorPrice = GetItemInfo(itemLink)
+
+            -- get correct level for scaling gear (heirlooms, 13th anniversary world bosses, etc
+            local level = ItemUpgradeInfo:GetUpgradedItemLevel(link) or 0
+
             -- find all equippable, non-artifact items
             if IsEquippableItem(itemLink) and quality ~= 6 then
               bagItems[#bagItems + 1] = {
                 string = GetItemStringFromItemLink(slotNum, itemLink, false),
-                name = name .. ' (' .. iLevel .. ')'
+                name = name .. ' (' .. level .. ')'
               }
             end
           end


### PR DESCRIPTION
**Please double check my .pkgmeta and TOC changes as I haven't done these before**

Default API's GetItemInfo does not provide the correct item level for
heirloom/scaled items (such as some of the new items from the 13th
anniversary world bosses).

LibItemUpgradeInfo performs tooltip scanning to get the correct item
level which I have the simc addon now using to make sure that the
comments for items line up with what is seen in-game.