### PR TITLE
Fix 7.3.5

### DIFF
--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -2,7 +2,7 @@
 ## Title: Simulationcraft
 ## Notes: Constructs SimC export strings
 ## Author: Theck, navv_
-## Version: 1.8.4
+## Version: 1.8.5
 ## OptionalDependencies: Ace3
 
 libs\LibStub\LibStub.lua

--- a/core.lua
+++ b/core.lua
@@ -191,12 +191,12 @@ function Simulationcraft:OpenArtifact()
     return false, false, 0
   end
 
-  if not select(1, IsUsableItem(itemId)) then
-    if not artifactFrameOpen then
-      HideUIPanel(ArtifactFrame)
-    end
-    return false, false, 0
-  end
+  -- if not select(1, IsUsableItem(itemId)) then
+  --   if not artifactFrameOpen then
+  --     HideUIPanel(ArtifactFrame)
+  --   end
+  --   return false, false, 0
+  -- end
 
   local mhId = select(1, GetInventoryItemID("player", GetInventorySlotInfo("MainHandSlot")))
   local ohId = select(1, GetInventoryItemID("player", GetInventorySlotInfo("SecondaryHandSlot")))


### PR DESCRIPTION
7.3.5 game client now returns `false false` for `IsUsableItem` when an artifact ID is provided. This short circuited the whole artifact/crucible output.

I'm not sure what this guard was defending against so there may need to be a followup if this sanity check was needed for some other edge case.