### PR TITLE
Allows multibute chars in realm names, fixes current region

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -6,3 +6,6 @@ externals:
   libs/LibItemUpgradeInfo-1.0:
     url: git://git.wowace.com/wow/libitemupgradeinfo-1-0/mainline.git
     tag: latest
+  libs/LibRealmInfo:
+    url: https://github.com/phanx-wow/LibRealmInfo.git
+    tag: latest

--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -2,7 +2,7 @@
 ## Title: Simulationcraft
 ## Notes: Constructs SimC export strings
 ## Author: Theck, navv_, seriallos
-## Version: 1.8.9
+## Version: 1.8.10-alpha-1
 ## OptionalDependencies: Ace3
 
 libs\LibStub\LibStub.lua
@@ -12,6 +12,7 @@ libs\AceAddon-3.0\AceAddon-3.0.xml
 libs\AceConsole-3.0\AceConsole-3.0.xml
 libs\AceEvent-3.0\AceEvent-3.0.xml
 libs\LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.xml
+libs\LibRealmInfo\LibRealmInfo.lua
 #@end-no-lib-strip@
 
 embeds.xml

--- a/core.lua
+++ b/core.lua
@@ -543,11 +543,19 @@ function Simulationcraft:PrintSimcProfile(debugOutput, noBags)
   local versionComment = '# SimC Addon ' .. GetAddOnMetadata('Simulationcraft', 'Version')
 
   -- Basic player info
+  local _, realmName, _, _, _, _, region, _, _, realmLatinName, _ = LibRealmInfo:GetRealmInfoByUnit('player')
+
   local playerName = UnitName('player')
   local _, playerClass = UnitClass('player')
   local playerLevel = UnitLevel('player')
-  local playerRealm = GetRealmName()
-  local playerRegion = string.lower(LibRealmInfo:GetCurrentRegion())
+
+  -- Try Latin name for Russian servers first, then realm name from LibRealmInfo, then Realm Name from the game
+  -- Latin name for Russian servers as most APIs use the latin name, not the cyrillic name
+  local playerRealm = realmLatinName() or realmName or GetRealmName()
+
+  -- Try region from LibRealmInfo first, then use default API
+  -- Default API can be wrong for region-switching players
+  local playerRegion = region or regionString[GetCurrentRegion()]
 
   -- Race info
   local _, playerRace = UnitRace('player')

--- a/core.lua
+++ b/core.lua
@@ -2,6 +2,7 @@ local _, Simulationcraft = ...
 
 Simulationcraft = LibStub("AceAddon-3.0"):NewAddon(Simulationcraft, "Simulationcraft", "AceConsole-3.0", "AceEvent-3.0")
 ItemUpgradeInfo = LibStub("LibItemUpgradeInfo-1.0")
+LibRealmInfo = LibStub("LibRealmInfo")
 
 local OFFSET_ITEM_ID = 1
 local OFFSET_ENCHANT_ID = 2
@@ -80,6 +81,21 @@ local function GetItemSplit(itemLink)
   return itemSplit
 end
 
+-- char size for utf8 strings
+local function chsize(char)
+  if not char then
+      return 0
+  elseif char > 240 then
+      return 4
+  elseif char > 225 then
+      return 3
+  elseif char > 192 then
+      return 2
+  else
+      return 1
+  end
+end
+
 -- SimC tokenize function
 local function tokenize(str)
   str = str or ""
@@ -99,6 +115,11 @@ local function tokenize(str)
       -- keep %, +, ., _
     elseif str:byte(i)==37 or str:byte(i)==43 or str:byte(i)==46 or str:byte(i)==95 then
       s = s .. str:sub(i,i)
+      -- save all multibyte chars
+    elseif chsize(b) > 1 then
+      local offset = chsize(b) - 1
+      s = s .. str:sub(i, i + offset)
+      i = i + offset
     end
   end
   -- strip trailing spaces
@@ -526,7 +547,7 @@ function Simulationcraft:PrintSimcProfile(debugOutput, noBags)
   local _, playerClass = UnitClass('player')
   local playerLevel = UnitLevel('player')
   local playerRealm = GetRealmName()
-  local playerRegion = regionString[GetCurrentRegion()]
+  local playerRegion = string.lower(LibRealmInfo:GetCurrentRegion())
 
   -- Race info
   local _, playerRace = UnitRace('player')

--- a/core.lua
+++ b/core.lua
@@ -551,7 +551,7 @@ function Simulationcraft:PrintSimcProfile(debugOutput, noBags)
 
   -- Try Latin name for Russian servers first, then realm name from LibRealmInfo, then Realm Name from the game
   -- Latin name for Russian servers as most APIs use the latin name, not the cyrillic name
-  local playerRealm = realmLatinName() or realmName or GetRealmName()
+  local playerRealm = realmLatinName or realmName or GetRealmName()
 
   -- Try region from LibRealmInfo first, then use default API
   -- Default API can be wrong for region-switching players


### PR DESCRIPTION
This change attempts to handle the following:

* Fix `region=` to use the correct region (region switchers can get stuck on one region)
* Use Latin names for Russian servers, fall back to Cyrillic names if LibRealmInfo doesn't have it
* Get accented character to show up in `server=`

This does change the output for some realms:

e.g. Pozzo dell'Eternità will output as `server=pozzo_delleternità` instead of `server=pozzo_delleternit` (dropping the last character)

Russian realms will use the Latin name of the server if LibRealmInfo has it, otherwise it will fall back to the Cyrillic name.

it doesn't look like anything live in SimC depends on this right now. There's some old code that may have created links to wowhead and AMR but none of that looks to be running at this point. Given that it's not being used, I feel like it should be OK to reintroduce the accented/unicode characters and make it the responsibility of anyone who uses this data to convert/normalize the unicode into the URL versions for APIs and whatnot.