### PR TITLE
Add Mag'har Orcs & Dark Iron Dwarves handling

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -601,6 +601,10 @@ function Simulationcraft:PrintSimcProfile(debugOutput, noBags)
     playerRace = 'Night Elf'
   elseif playerRace == 'Scourge' then --lulz
     playerRace = 'Undead'
+  elseif playerRace == 'DarkIronDwarf' then
+    playerRace = 'Dark Iron Dwarf'
+  elseif playerRace == 'MagharOrc' then
+    playerRace = 'Maghar Orc'
   end
 
   -- Spec info


### PR DESCRIPTION
Simcraft just got support for the 2 new bfa races using `maghar_orc` & `dark_iron_dwarf` as names. Add proper support for this to the addon.