### PR TITLE
add LibRealmInfo as optional dependency

### DIFF
--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -3,7 +3,7 @@
 ## Notes: Constructs SimC export strings
 ## Author: Theck, navv_, seriallos
 ## Version: 1.10.6
-## OptionalDependencies: Ace3
+## OptionalDependencies: Ace3, LibRealmInfo
 
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.lua


### PR DESCRIPTION
This fixes nolib builds as there's no request for LibRealmInfo,
resulting the /no instance of LibRealmInfo found/ error in nolib builds.