### PR TITLE
Set Protection Warrior's default role to tank

### DIFF
--- a/extras.lua
+++ b/extras.lua
@@ -48,7 +48,7 @@ Simulationcraft.RoleTable = {
   -- Warrior
   [71] = 'attack',
   [72] = 'attack',
-  [73] = 'attack'
+  [73] = 'tank'
 }
 
 -- regionID lookup


### PR DESCRIPTION
Simulations with role=attack should be a niche use for tanks that don't want to model any kind of incoming damage on purpose and not the default.
For Protection, this impacts rage generation from damage taken as well as some azerite traits interactions