### PR TITLE
[Bugfix] Replace UnitBuff usage with C_UnitAuras.GetBuffDataByIndex

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -597,7 +597,8 @@ end
 function Simulationcraft:GetZandalariLoa()
   local zandalariLoa = nil
   for index = 1, 32 do
-    local _, _, _, _, _, _, _, _, _, spellId = UnitBuff("player", index)
+    local auraData = C_UnitAuras.GetBuffDataByIndex("player", index)
+    local spellId = auraData.spellId
     if spellId == nil then
       break
     end


### PR DESCRIPTION
UnitBuff was deprecated in 10.2.5, and is removed in 11.0.2. This commit replaces all instances of UnitBuff with C_UnitAuras.GetBuffDataByIndex. This function is similar to UnitBuff, but instead of returning multiple values, C_UnitAuras.GetBuffDataByIndex returns a table. Docs: https://warcraft.wiki.gg/wiki/API_C_UnitAuras.GetBuffDataByIndex

Using it on beta: 
![image](https://github.com/user-attachments/assets/ce2b17b6-bad1-4824-b325-2d828b4dd14e)
