### PR TITLE
add Addon Category

### DIFF
--- a/Simulationcraft.toc
+++ b/Simulationcraft.toc
@@ -6,6 +6,7 @@
 ## Version: 12.0.1-02
 ## OptionalDependencies: Ace3, LibRealmInfo, LibDBIcon, LibDataBroker-1.1
 ## SavedVariables: SimulationCraftDB
+## Category: Loot
 
 ## X-Curse-Project-ID: 82745
 ## X-Wago-ID: BNBeRVGx


### PR DESCRIPTION
This will add the addon to the category displayed on the addon overview:
<img width="378" height="200" alt="{2E89698C-7658-463A-8AA6-8103C52216D6}" src="https://github.com/user-attachments/assets/7392fde8-40b9-4586-8dc5-4ec546d6c244" />

There are some default values for these categories, feel free to suggest a different one:
https://warcraft.wiki.gg/wiki/Addon_Categories#Loot