### PR TITLE
Add Venomblight Manaflux (3465) to catalystCurrencies

### DIFF
--- a/extras.lua
+++ b/extras.lua
@@ -408,6 +408,7 @@ Simulationcraft.catalystCurrencies = {
   [3116] = 'Essence of Kaja\'mite',
   [3269] = 'Ethereal Voidsplinter',
   [3378] = 'Dawnlight Manaflux',
+  [3465] = 'Venomblight Manaflux',
 }
 
 Simulationcraft.bonusRollCurrencies = {


### PR DESCRIPTION
`Simulationcraft.catalystCurrencies` stops at `3378` (Dawnlight Manaflux, Midnight Season 1). Season 2's catalyst currency is `3465` Venomblight Manaflux, added in `12.1.0.69189`, so `GetCatalystCurrencies` never queries it and no export carries a balance.

Reproduced on 12.1.0-02 with a character holding 1 Venomblight:

before
```
# catalyst_currencies=3269:8/3378:8/2813:8/3116:8
```

after
```
# catalyst_currencies=2813:8/3269:8/3116:8/3378:8/3465:1
```

Same character, same session — the only change is the added id.

The Season 2 crests (`3442`–`3446`) were added to `upgradeCurrencies` in "Update 12.1 currencies, crests, achievements, etc" (2026-06-24); Venomblight shipped later in the patch and appears to have been missed.
